### PR TITLE
Fortran: fixed generating z-coordinate - now it's for limited range

### DIFF
--- a/test_project/code/star_generation/generator.f
+++ b/test_project/code/star_generation/generator.f
@@ -165,13 +165,9 @@ C             disk_belonging = 1 (thin disk), = 2 (thick disk)
 C             Coordinates of halo stars will be generated in polar.f
               if (disk_belonging(stars_count) /= 3) then
 C                 Inverse transform sampling for y = exp(-z / H)
-                  do
-                      random_value = ran(iseed)
-                      if (random_value /= 0.0) then
-                          exit
-                      end if
-                  end do
-                  z_coordinate = -scale_height * log(random_value)
+                  z_coordinate = -scale_height * log(
+     &                1.0 - ran(iseed) * (1.0 - exp(-radius
+     &                                              / scale_height)))
 C                 Assigning random sign
                   in = int(2.0 * ran(iseed))
                   coordinate_Zcylindr(stars_count) = z_coordinate 


### PR DESCRIPTION
- Deleted exact comparison for real type variable
- Fixed generating z-coordinates:

At first, `z_coordinate` was generated for a limitless range.
It's wrong as we generate stars for a spherical distribution in this module.
New distribution was calculated by [inverse transformation method](https://en.wikipedia.org/wiki/Inverse_transform_sampling).
For this new distribution we can check that for `ran(iseed) == 0` we will have `z_coordinate == 0` and for `ran(iseed) == 1` it will be  `z_coordinate == radius`